### PR TITLE
Do no harm

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If your `package.json` contains, as example, these entries:
 {
   "name": "hyperhtml",
   "scripts": {
-    "postinstall": "opencollective postinstall"
+    "postinstall": "opencollective postinstall || exit 0"
   },
   "dependencies": {
     "opencollective": "^1.0.3"
@@ -33,7 +33,7 @@ all you need to do is to replace `postinstall` and `dependencies` with `lighterc
 {
   "name": "hyperhtml",
   "scripts": {
-    "postinstall": "lightercollective"
+    "postinstall": "lightercollective || exit 0"
   },
   "dependencies": {
     "lightercollective": "^0.0.0"


### PR DESCRIPTION
Update the usage examples to demonstrate using opencollective/lightercollective in a manner that won't cause other things to fail in the event that opencollective/lightercollective fails (as can happen in some CI and offline scenarios). Arguably, displaying a banner soliciting project funding shouldn't cause downstream operations to fail in projects using a library that uses opencollective/lightercollective.