### PR TITLE
Make lightercollective even lighter

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.3.0",
   "description": "a basic postinstall only binary based on package.json collective info",
   "bin": "./index.js",
+  "files": [
+    "index.js"
+  ],
   "keywords": [
     "opencollective",
     "postinstall",


### PR DESCRIPTION
If we define the files npm bundles in the package.json, we can ensure to
exclude tests.